### PR TITLE
Removed 'random.seed()' to allow replication

### DIFF
--- a/libpgm/CPDtypes/discrete.py
+++ b/libpgm/CPDtypes/discrete.py
@@ -62,7 +62,7 @@ class Discrete():
         The function goes to the proper entry in *Vdataentry*, as specified by *pvalues*, and samples the node based on the distribution found there. 
 
         '''
-        random.seed()
+
 
         p = self.Vdataentry["parents"]
         if (not p):

--- a/libpgm/CPDtypes/lg.py
+++ b/libpgm/CPDtypes/lg.py
@@ -67,7 +67,7 @@ class Lg():
         The function creates a Gaussian distribution in the manner described in :doc:`lgbayesiannetwork`, and samples from that distribution, returning its outcome.
         
         '''
-        random.seed()
+
 
         # calculate Bayesian parameters (mean and variance)
         mean = self.Vdataentry["mean_base"]

--- a/libpgm/CPDtypes/lgandd.py
+++ b/libpgm/CPDtypes/lgandd.py
@@ -78,7 +78,7 @@ class Lgandd():
         The function goes to the entry of ``"cprob"`` that matches the outcomes of its discrete parents. Then, it constructs a Gaussian distribution based on its Gaussian parents and the parameters found at that entry. Last, it samples from that distribution and returns its outcome.
 
         '''
-        random.seed()
+
 
         # split parents by type
         dispvals = []

--- a/libpgm/discretebayesiannetwork.py
+++ b/libpgm/discretebayesiannetwork.py
@@ -179,7 +179,7 @@ class DiscreteBayesianNetwork(OrderedSkeleton):
         '''
         assert (isinstance(n, int) and n > 0), "Argument must be a positive integer."
         
-        random.seed()
+
         seq = []
         for _ in range(n):
             outcome = dict()

--- a/libpgm/dyndiscbayesiannetwork.py
+++ b/libpgm/dyndiscbayesiannetwork.py
@@ -129,7 +129,7 @@ class DynDiscBayesianNetwork(OrderedSkeleton):
         '''
         assert (isinstance(n, int) and n > 0), "Argument must be a positive integer."
 
-        random.seed()
+
         seq = []
         for t in range(n):
             outcome = dict()

--- a/libpgm/hybayesiannetwork.py
+++ b/libpgm/hybayesiannetwork.py
@@ -118,7 +118,7 @@ class HyBayesianNetwork(OrderedSkeleton):
         '''
         assert (isinstance(n, int) and n > 0), "Argument must be a positive integer."
         
-        random.seed()
+
         seq = []
         for _ in range(n):
             outcome = dict()

--- a/libpgm/lgbayesiannetwork.py
+++ b/libpgm/lgbayesiannetwork.py
@@ -128,7 +128,7 @@ class LGBayesianNetwork(OrderedSkeleton):
         '''
         assert (isinstance(n, int) and n > 0), "Argument must be a positive integer."
 
-        random.seed()
+
         seq = []
         distribseq = []
         for _ in range(n):

--- a/libpgm/tablecpdfactorization.py
+++ b/libpgm/tablecpdfactorization.py
@@ -356,7 +356,7 @@ class TableCPDFactorization():
 
         '''
         self.refresh()
-        random.seed() 
+
         
         # declare result array
         seq = []


### PR DESCRIPTION
Seed should instead be set before the package is run - to allow for replication.

When random.seed(xx) is not used before the functions are run, the random generator will be initialized with some system parameters like time. When it is used, e.g. random.seed(999), it will set a random number generator for the use in all subsequently called functions in libpgm, and the process will be replicable.