### PR TITLE
fix zero division error

### DIFF
--- a/libpgm/tablecpdfactorization.py
+++ b/libpgm/tablecpdfactorization.py
@@ -417,8 +417,9 @@ class TableCPDFactorization():
                     summ = 0
                     for val in relevantfactors[0].vals:
                         summ += val
-                    for x in range(len(relevantfactors[0].vals)):
-                        relevantfactors[0].vals[x] /= summ
+                    if summ > 0:
+                        for x in range(len(relevantfactors[0].vals)):
+                            relevantfactors[0].vals[x] /= summ
 
                 # convert random number
                 val = random.random()


### PR DESCRIPTION
Fix zero division error on Gibbs sampling from learned network:

```python
Traceback (most recent call last):
  File "../scripts/infer_network.py", line 57, in <module>
    "class": "tea"})
  File "../scripts/infer_network.py", line 49, in infer
    result = agg.aggregate(cpd.gibbssample(evidence, self.sample_num)[burn_in:])
  File "/usr/local/lib/python2.7/dist-packages/libpgm/tablecpdfactorization.py", line 432, in gibbssample
    seq.append(next(copy))
  File "/usr/local/lib/python2.7/dist-packages/libpgm/tablecpdfactorization.py", line 407, in next
    relevantfactors[0].vals[x] /= summ
ZeroDivisionError: float division by zero
```